### PR TITLE
fix: github oauth error if github namee is blank

### DIFF
--- a/packages/server/src/modules/auth/strategies/github.strategy.ts
+++ b/packages/server/src/modules/auth/strategies/github.strategy.ts
@@ -49,7 +49,7 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
       const newUser = await this.prisma.user.create({
         data: {
           username: login,
-          displayName: name,
+          displayName: name ?? login,
         },
       });
 


### PR DESCRIPTION
# [ PULL REQUEST ]

## 관련 이슈

깃허브 name이 없을 경우 깃허브 로그인 시 에러가 발생함
user이 없을 경우 login값으로 넣음으로 해결함

## PR Point

## 실제 소요시간

## 어려웠던 점
